### PR TITLE
Fixplurals

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -138,7 +138,7 @@ type userResponse struct {
 }
 
 type usersResponse struct {
-	Users []users.User `json:"users"`
+	Users []users.User `json:"customer"`
 }
 
 type addressPostRequest struct {
@@ -147,7 +147,7 @@ type addressPostRequest struct {
 }
 
 type addressesResponse struct {
-	Addresses []users.Address `json:"addresses"`
+	Addresses []users.Address `json:"address"`
 }
 
 type cardPostRequest struct {
@@ -156,7 +156,7 @@ type cardPostRequest struct {
 }
 
 type cardsResponse struct {
-	Cards []users.Card `json:"cards"`
+	Cards []users.Card `json:"card"`
 }
 
 type registerRequest struct {

--- a/apispec/user.json
+++ b/apispec/user.json
@@ -396,8 +396,6 @@
                "required":[  
                   "self",
                   "customer",
-                  "addresses",
-                  "cards"
                ]
             }
          },

--- a/apispec/user.json
+++ b/apispec/user.json
@@ -302,7 +302,7 @@
             "_embedded":{  
                "type":"object",
                "properties":{  
-                  "cards":{  
+                  "card":{  
                      "type":"array",
                      "items":{  
                         "$ref":"#/definitions/Card"
@@ -525,7 +525,7 @@
             "_embedded":{  
                "type":"object",
                "properties":{  
-                  "addresses":{  
+                  "address":{  
                      "type":"array",
                      "items":{  
                         "$ref":"#/definitions/Address"

--- a/users/links.go
+++ b/users/links.go
@@ -42,6 +42,21 @@ func (l *Links) AddCard(id string) {
 	l.AddLink("card", id)
 }
 
+func (l *Links) AddAttrLink(attr string, id string) {
+	link := fmt.Sprintf("http://%v/%v/%v", domain, entitymap[attr], id)
+	nl := *l
+	nl[attr] = Href{link}
+	*l = nl
+}
+
+func (l *Links) AddAttrAddress(id string) {
+	l.AddAttrLink("address", id)
+}
+
+func (l *Links) AddAttrCard(id string) {
+	l.AddAttrLink("card", id)
+}
+
 type Href struct {
 	string `json:"href"`
 }

--- a/users/links.go
+++ b/users/links.go
@@ -45,7 +45,7 @@ func (l *Links) AddCard(id string) {
 func (l *Links) AddAttrLink(attr string, id string) {
 	link := fmt.Sprintf("http://%v/%v/%v", domain, entitymap[attr], id)
 	nl := *l
-	nl[attr] = Href{link}
+	nl[entitymap[attr]] = Href{link}
 	*l = nl
 }
 

--- a/users/users.go
+++ b/users/users.go
@@ -61,10 +61,12 @@ func (u *User) AddLinks() {
 	for k, c := range u.Cards {
 		c.AddLinks()
 		u.Cards[k] = c
+		u.Links.AddAttrCard(c.ID)
 	}
 	for k, a := range u.Addresses {
 		a.AddLinks()
 		u.Addresses[k] = a
+		u.Links.AddAttrAddress(a.ID)
 	}
 }
 


### PR DESCRIPTION
This changes the json tags from plurals to singular for the arrays of customers, addresses, and cards.

This also add links for cards and addresses to the top level links object of the customer.

@philwinder @idcrosby @alex-glv @mongrelion 