### PR TITLE
updated .travis.yml to specify go 1.7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.7
+go: 1.7.5
 sudo: required
 env:
 - GROUP=weaveworksdemos COMMIT=$TRAVIS_COMMIT TAG=$TRAVIS_TAG

--- a/scripts/testcontainer.sh
+++ b/scripts/testcontainer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sleep 2
+sleep 10
 RESPONSECODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8084/customers)
 if [ $RESPONSECODE != 200 ]
 	then


### PR DESCRIPTION
I edited .travis.yml to specify go 1.7.5 since I think this might be needed to actually use Go 1.7.5 in the user app on the Docker images despite https://github.com/microservices-demo/user/blob/master/Dockerfile being built from golang:1.7-alpine which currently already uses Go 1.7.5.  This is in connection with https://github.com/microservices-demo/user/issues/46.

Thanks.