### PR TITLE
Rename HTTP metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,10 +30,10 @@ var (
 
 var (
 	HTTPLatency = stdprometheus.NewHistogramVec(stdprometheus.HistogramOpts{
-		Name:    "request_duration_seconds",
+		Name:    "http_request_duration_seconds",
 		Help:    "Time (in seconds) spent serving HTTP requests.",
 		Buckets: stdprometheus.DefBuckets,
-	}, []string{"method", "route", "status_code", "isWS"})
+	}, []string{"method", "path", "status_code", "isWS"})
 )
 
 const (


### PR DESCRIPTION
Renames metrics from request_duration_seconds => http_request_duration_seconds and replaces the route label with path.