### PR TITLE
Avoid granting Linux capabilities

### DIFF
--- a/docker/user/Dockerfile-release
+++ b/docker/user/Dockerfile-release
@@ -16,21 +16,19 @@ ENV	SERVICE_USER=myuser \
 	SERVICE_GID=10001
 
 RUN	addgroup -g ${SERVICE_GID} ${SERVICE_GROUP} && \
-	adduser -g "${SERVICE_NAME} user" -D -H -G ${SERVICE_GROUP} -s /sbin/nologin -u ${SERVICE_UID} ${SERVICE_USER} && \
-	apk add --update libcap
+	adduser -g "${SERVICE_NAME} user" -D -H -G ${SERVICE_GROUP} -s /sbin/nologin -u ${SERVICE_UID} ${SERVICE_USER}
 
 ENV HATEAOS user
 ENV USER_DATABASE mongodb
 ENV MONGO_HOST user-db
 
 WORKDIR /
-EXPOSE 80
+EXPOSE 8080
 COPY --from=0 /user /
 
 RUN	chmod +x /user && \
-	chown -R ${SERVICE_USER}:${SERVICE_GROUP} /user && \
-	setcap 'cap_net_bind_service=+ep' /user
+	chown -R ${SERVICE_USER}:${SERVICE_GROUP} /user
 
 USER ${SERVICE_USER}
 
-CMD ["/user", "-port=80"]
+CMD ["/user", "-port=8080"]


### PR DESCRIPTION
My task was to run your Helm chart on K8s cluster with restrictive pod security policy. The worst problem I encountered was that you grant Linux capabilities in order to bind 80 port inside of container. As a result I was not able to run these images in any way without rebuilding them reverting this operation. That's why I propose you to use other port inside of containers and map it externally to 80 during running a container.